### PR TITLE
disable email notifications from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ install:
 
 script: tox -e $TOX_ENV
 
+notifications:
+  email: false


### PR DESCRIPTION
travis would send email to every committer on every failed build for every galaxy instance running travis (ie this one and jmchilton one)
we have enough visibility of runs on PR statuses so I think we do not need this
